### PR TITLE
README mentions the executable's name wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ Therefore, this independent tool was made.
 ## Caveats
 
 * Sometimes YARD doesn't provide enough information to guess in which line of code the problem is;
-  in those cases `junk-yard` just writes something like `file.rb:1` (to stay consistent and not break
+  in those cases `yard-junk` just writes something like `file.rb:1` (to stay consistent and not break
   go-to-file tools);
 * Checking of links to files and URLs proven to be incomplete.
 


### PR DESCRIPTION
This PR fixes a typo in the README.

(I heard about this gem via Solnica's tweet about it.)