### PR TITLE
Gemspec: exclude more build-related files

### DIFF
--- a/yard-junk.gemspec
+++ b/yard-junk.gemspec
@@ -18,10 +18,13 @@ Gem::Specification.new do |s|
     spec\/.*
     |Gemfile
     |Rakefile
+    |codeclimate.yml
     |\.rspec
     |\.gitignore
     |\.rubocop.yml
+    |\.rubocop_todo.yml
     |\.travis.yml
+    |\.yardopts
     )$/x
   end
   s.require_paths = ["lib"]


### PR DESCRIPTION
This PR adds more files to the file list of exclusions in the gemspec.