### PR TITLE
Travis: use a single default task for builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,3 @@ rvm:
   - ruby-head
 install:
   - bundle install --retry=3
-script:
-  - bundle exec rspec
-  - bundle exec rubocop
-  - bundle exec rake yard:junk

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,11 @@ Gem::Tasks.new
 
 require_relative 'lib/yard-junk/rake'
 YardJunk::Rake.define_task
+
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new
+
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+
+task default: %w[spec rubocop yard:junk]


### PR DESCRIPTION
This PR adds a `default` rake task and uses it for CI builds.

This is used in Travis builds as the default `script` action. (For `language: ruby`, it is: `bundle exec rake`.)

And it builds green: 🍏 

(This change pays off more in JRuby, where starting is costlier. Here, it's mostly simplicity.)