### PR TITLE
Typo fix in Rake task desc

### DIFF
--- a/lib/yard-junk/rake.rb
+++ b/lib/yard-junk/rake.rb
@@ -5,7 +5,7 @@ module YardJunk
     extend ::Rake::DSL
 
     def self.define_task
-      desc 'Check th junk in your YARD Documentation'
+      desc 'Check the junk in your YARD Documentation'
       task('yard:junk') do
         require 'yard'
         require_relative '../yard-junk'


### PR DESCRIPTION
This PR fixes a typo in the description of the Rake task provided.