### PR TITLE
Gemfile: add custom github: gems source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
 gemspec
 
 group :test do


### PR DESCRIPTION
This PR adds a line to the gemspec which is in Bundler's "new gem template". 

  - this avoid warning output from Bundler when installing 