### PR TITLE
Typo: .codeclimate.yml starts with a dot

### DIFF
--- a/yard-junk.gemspec
+++ b/yard-junk.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     spec\/.*
     |Gemfile
     |Rakefile
-    |codeclimate.yml
+    |\.codeclimate.yml
     |\.rspec
     |\.gitignore
     |\.rubocop.yml


### PR DESCRIPTION
This PR fixes an issue introduced by me: a typo.