### PR TITLE
TextReporter: colorize failure count

### DIFF
--- a/lib/yard-junk/janitor/text_reporter.rb
+++ b/lib/yard-junk/janitor/text_reporter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rainbow'
+
 module YardJunk
   class Janitor
     # Reporter that just outputs everything in plaintext format. Useful
@@ -9,9 +11,27 @@ module YardJunk
       private
 
       def _stats(**stat)
-        line =
-          '%<errors>i failures, %<problems>i problems (%<duration>s to run)' % stat
-        @io.puts "\n#{line}"
+        @io.puts "\n#{template_for(stat) % stat}"
+      end
+
+      NO_ISSUES_TEMPLATE = [
+        Rainbow('%<errors>i failures, %<problems>i problems').green,
+        Rainbow(', (%<duration>s to run)').gray
+      ].join('').freeze
+
+      ERROR_COUNT_TEMPLATE = [
+        Rainbow('%<errors>i failures').red,
+        Rainbow(',').gray,
+        Rainbow(' %<problems>i problems').yellow,
+        Rainbow(', (%<duration>s to run)').gray
+      ].join('').freeze
+
+      def template_for(stat)
+        if stat[:errors].zero? && stat[:problems].zero?
+          NO_ISSUES_TEMPLATE
+        else
+          ERROR_COUNT_TEMPLATE
+        end
       end
 
       def header(title, explanation)

--- a/spec/yard-junk/janitor/text_reporter_spec.rb
+++ b/spec/yard-junk/janitor/text_reporter_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe YardJunk::Janitor::TextReporter do
       )
     }
 
-    its_call { is_expected.to send_message(out, :puts).with("\n3 failures, 2 problems (5 seconds to run)") }
+    its_call { is_expected.to send_message(out, :puts).with("\n\e[31m3 failures\e[0m\e[38;5;188m,\e[0m\e[33m 2 problems\e[0m\e[38;5;188m, (5 seconds to run)\e[0m") }
   end
 
   describe '#finalize' do

--- a/yard-junk.gemspec
+++ b/yard-junk.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.bindir = 'exe'
   s.executables << 'yard-junk'
 
+  s.add_dependency 'rainbow'
   s.add_dependency 'yard'
   if RUBY_VERSION < '2.4'
     s.add_dependency 'did_you_mean', '~> 1.0'


### PR DESCRIPTION
This PR is about _Colorized output for text reporter_ from the ROADMAP.

This change introduces [Rainbow](https://github.com/sickill/rainbow) as a dependency, to do ANSI escape sequences.

[Rainbow is sensitive about tty](https://github.com/sickill/rainbow#configuration):

> When disabled all the methods return an unmodified string (`Rainbow("hello").red == "hello"`).
>
> It's enabled by default, unless STDOUT/STDERR is not a TTY or a terminal is dumb.

