### PR TITLE
Travis: jruby-9.1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
     - rvm: 2.2
     - rvm: 2.1
     - rvm: jruby
-    - rvm: jruby-9.1.12.0
+    - rvm: jruby-9.1.13.0
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby
-    - rvm: jruby-9.1.12.0
+    - rvm: jruby-9.1.13.0
 install:
   - bundle install --retry=3
 script: bundle exec rake


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/09/06/jruby-9-1-13-0.html