### PR TITLE
CI: use "3.0", too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, head ]
+        ruby: [ 2.5, 2.6, 2.7, "3.0", head ]
 
     steps:
       - name: checkout


### PR DESCRIPTION
YAML float-to-string conversion issues avoided.